### PR TITLE
Changed Makefile to get make run without error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ $(EXECUTABLE): $(OBJECTS)
 	$(CXX) $(LDLIBS) $(OBJECTS) -o $@
 
 $(OBJDIR)/%.o : $(SRCDIR)/%.cpp
-	$(CXX) $(CFLAGS) -g -c $< -o $@
+	mkdir -p $(OBJDIR)
+	$(CXX) $(CFLAGS)  -g -c $< -o $@
 
 clean:
 	rm -f $(EXECUTABLE) $(OBJDIR)/*


### PR DESCRIPTION
g++ complains about nonexistent object directory which is now ensured to exist.
